### PR TITLE
OpenBSD support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ LIBS+=-lcrypto
 all: opmsg
 
 opmsg: keystore.o opmsg.o misc.o config.o message.o marker.o base64.o deleters.o
-	$(LD) $(LDFLAGS) $^ $(LIBS) -o opmsg
+	$(LD) $(LDFLAGS) keystore.o opmsg.o misc.o config.o message.o marker.o base64.o deleters.o $(LIBS) -o $@
 
 opmsg.o: opmsg.cc
 	$(CXX) $(CXXFLAGS) -c $<
@@ -44,6 +44,4 @@ test: test2.cc test1.cc keystore.o config.o misc.o message.o base64.o marker.o d
 	$(CXX) $(CXXFLAGS) test2.cc keystore.o config.o misc.o base64.o marker.o message.o deleters.o $(LIBS) -o test2
 
 clean:
-	rm -rf *.o
-
-
+	rm -rf *.o opmsg

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ Build
 _opmsg_ requires the crypto primitives from _OpenSSL_. Just relax, its
 not using the SSL/TLS proto, just the ciphering and hash algorithms.
 
+The compilation requires a C++ compiler that supports c++11. This can be
+configured with e.g. `make CXX=eg++ LD=eg++` .
+
+This project supports both `BN_GENCB_new` and `BN_GENCB` for big number
+generation. To disable `BN_GENCB_new`, set `HAVE_BN_GENCB_NEW` to false:
+`make DEFS=-DHAVE_BN_GENCB_NEW=0`
+
 ```
 $ make
 [...]
@@ -67,8 +74,8 @@ Usage: opmsg    [--confdir dir] [--rsa] [--encrypt dst-ID] [--decrypt] [--sign]
         --name,         -n      use this name for newly created personas
 ```
 
-It successfully builds on _Linux_ and _OSX_, and probably a lot of others
-(_Solaris_, _BSD_,...).
+It successfully builds on _Linux_, _OSX_, _OpenBSD_, and probably a lot of
+others (_Solaris_, _FreeBSD_, ...).
 
 Personas
 --------

--- a/keystore.cc
+++ b/keystore.cc
@@ -177,8 +177,7 @@ int keystore::gen_rsa(string &pub, string &priv)
 		return build_error("gen_rsa::BN_dec2b: Error generating RSA key", -1);
 	e.reset(b);
 
-// In OpenSSL 1.1.0, static decl of BN_GENCB disappeared and before BN_GENCB_new was bot there!
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if HAVE_BN_GENCB_NEW
 	unique_ptr<BN_GENCB, BN_GENCB_del> cb(BN_GENCB_new(), BN_GENCB_free);
 	if (!(cb_ptr = cb.get()))
 		return build_error("gen_rsa: OOM", -1);
@@ -612,8 +611,7 @@ DHbox *persona::new_dh_params()
 	if (RAND_load_file("/dev/urandom", 256) != 256)
 		RAND_load_file("/dev/random", 8);
 
-// In OpenSSL 1.1.0, static decl of BN_GENCB disappeared and before BN_GENCB_new was bot there!
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if HAVE_BN_GENCB_NEW
 	unique_ptr<BN_GENCB, BN_GENCB_del> cb(BN_GENCB_new(), BN_GENCB_free);
 	if (!(cb_ptr = cb.get()))
 		return build_error("gen_rsa: OOM", nullptr);

--- a/keystore.h
+++ b/keystore.h
@@ -39,6 +39,11 @@ extern "C" {
 #include <openssl/err.h>
 }
 
+// In OpenSSL 1.1.0, static decl of BN_GENCB disappeared and before
+// BN_GENCB_new was bot there!
+#ifndef HAVE_BN_GENCB_NEW
+#define HAVE_BN_GENCB_NEW OPENSSL_VERSION_NUMBER >= 0x10100000L
+#endif
 
 namespace opmsg {
 

--- a/misc.cc
+++ b/misc.cc
@@ -40,7 +40,7 @@ string &blob2hex(const string &blob, string &hex)
 
 	hex = "";
 	for (string::size_type i = 0; i < blob.size(); ++i) {
-		sprintf(h, "%02x", 0xff&blob[i]);
+		snprintf(h, 3, "%02x", 0xff&blob[i]);
 		hex += h;
 	}
 	return hex;


### PR DESCRIPTION
- Requires the g++ package.
- The GNU Make `$^` is not supported by BSD make(1); list the
  prerequisites explicitly for compatibility and simplicity.
- `BN_GENCB_new` isn't in LibreSSL, so expose the ability to fall back
  to `BN_GENCB`.
- Use snprintf(3) instead of sprintf(3).

Unrelated: also delete the binary in the `clean` target.

Compile on OpenBSD using:

    make CXX=eg++ LD=eg++ DEFS=-DHAVE_BN_GENCB_NEW=0

Works for me on -current from 19 April 2015.