### PR TITLE
Compile in Cygwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,13 @@ opmsg: keystore.o opmsg.o misc.o config.o message.o marker.o base64.o deleters.o
 	$(LD) $(LDFLAGS) keystore.o opmsg.o misc.o config.o message.o marker.o base64.o deleters.o $(LIBS) -o $@
 
 opmsg.o: opmsg.cc
-	$(CXX) $(CXXFLAGS) -c $<
+	$(CXX) $(CXXFLAGS) -U__STRICT_ANSI__ -c $<
 
 marker.o: marker.cc marker.h
 	$(CXX) $(CXXFLAGS) -c $<
 
 keystore.o: keystore.cc keystore.h
-	$(CXX) $(CXXFLAGS) -c $<
+	$(CXX) $(CXXFLAGS) -U__STRICT_ANSI__ -c $<
 
 base64.o: base64.cc base64.h
 	$(CXX) $(CXXFLAGS) -c $<

--- a/config.cc
+++ b/config.cc
@@ -95,15 +95,15 @@ int parse_config(const string &cfgbase)
 		else if (sline.find("rsa_e=") == 0)
 			config::rsa_e = sline.substr(6);
 		else if (sline.find("rsa_len=") == 0) {
-			config::rsa_len = stoi(sline.substr(8));
+			config::rsa_len = strtol(sline.substr(8).c_str(), NULL, 0);
 			if (config::rsa_len < 1024 || config::rsa_len > 16000)
 				config::rsa_len = 4096;
 		} else if (sline.find("dh_plen=") == 0) {
-			config::dh_plen = stoi(sline.substr(8));
+			config::dh_plen = strtol(sline.substr(8).c_str(), NULL, 0);
 			if (config::dh_plen < 512 || config::dh_plen > 8192)
 				config::dh_plen = 1024;
 		} else if (sline.find("new_dh_keys=") == 0) {
-			config::new_dh_keys = stoi(sline.substr(12));
+			config::new_dh_keys = strtol(sline.substr(12).c_str(), NULL, 0);
 			if (config::new_dh_keys < 0 || config::new_dh_keys > 100)
 				config::new_dh_keys = 3;
 		} else if (sline == "rsa_override")


### PR DESCRIPTION
The following changes are required to make opmsg compile in cygwin. I am not particularly happy with -U__STRING_ANSI__ in the Makefile, and you may decide there is a better way.

For reference on the two cygwin-related issues:
http://stackoverflow.com/questions/21689124/mkstemp-and-fdopen-in-cygwin-1-7-28
http://stackoverflow.com/questions/20145488/cygwin-g-stdstoi-error-stoi-is-not-a-member-of-std